### PR TITLE
Convert linefeeds at build time to make sure it is independent on how…

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -19,7 +19,10 @@ dsk2cdt: $(DSK2CDT_OBJS) $(2CDT_OBJS) $(RAW_OBJS) $(SHARED_OBJS)
 	@echo "Linking $@"
 	@$(CC) $(CFLAGS) $(INCLUDES) -o $@ $^
 
-loader.o: loader.txt rsx.bin
+loader_donotedit.crlf.bin: loader.txt
+	unix2dos -n $< $@.tmp && mv -vf $@.tmp $@
+
+loader.o: loader_donotedit.crlf.bin rsx.bin
 	$(LD) -r -b binary -o $@ $^
 
 rsx.bin: rsx.s

--- a/src/dsk2cdt-src/loader.h
+++ b/src/dsk2cdt-src/loader.h
@@ -29,9 +29,9 @@ extern size_t binary_rsx_bin_size[];
 extern char _binary___dsk2cdt_src_loader_txt_start[];
 extern char _binary___dsk2cdt_src_loader_txt_end[];
 extern char _binary___dsk2cdt_src_loader_txt_size[];
-extern char _binary___dsk2cdt_src_rsx_bin_start[];
-extern size_t _binary___dsk2cdt_src_rsx_bin_end[];
-extern size_t _binary___dsk2cdt_src_rsx_bin_size[];
+extern char _binary_rsx_bin_start[];
+extern size_t _binary_rsx_bin_end[];
+extern size_t _binary_rsx_bin_size[];
 
 // the symbols out of ld are unwieldy, so make them easier to work with.
 // gcc doesn't let us do symbol aliasing with external symbols, bah
@@ -40,9 +40,9 @@ extern size_t _binary___dsk2cdt_src_rsx_bin_size[];
 #define loader_txt_end     _binary___dsk2cdt_src_loader_txt_end
 #define loader_txt_size    _binary___dsk2cdt_src_loader_txt_size
 
-#define rsx_bin_start      _binary___dsk2cdt_src_rsx_bin_start
-#define rsx_bin_end        _binary___dsk2cdt_src_rsx_bin_end
-#define rsx_bin_size       _binary___dsk2cdt_src_rsx_bin_size
+#define rsx_bin_start      _binary_rsx_bin_start
+#define rsx_bin_end        _binary_rsx_bin_end
+#define rsx_bin_size       _binary_rsx_bin_size
 
 #endif
 

--- a/src/dsk2cdt-src/loader.h
+++ b/src/dsk2cdt-src/loader.h
@@ -4,9 +4,9 @@
 #ifdef _WIN32
 // symbols exported by loader.o
 
-extern char binary___dsk2cdt_src_loader_txt_start[];
-extern char binary___dsk2cdt_src_loader_txt_end[];
-extern char binary___dsk2cdt_src_loader_txt_size[];
+extern char binary___loader_donotedit_crlf_bin_start[];
+extern char binary___loader_donotedit_crlf_bin_end[];
+extern char binary___loader_donotedit_crlf_bin_size[];
 extern char binary_rsx_bin_start[];
 extern size_t binary_rsx_bin_end[];
 extern size_t binary_rsx_bin_size[];
@@ -14,9 +14,9 @@ extern size_t binary_rsx_bin_size[];
 // the symbols out of ld are unwieldy, so make them easier to work with.
 // gcc doesn't let us do symbol aliasing with external symbols, bah
 
-#define loader_txt_start   binary___dsk2cdt_src_loader_txt_start
-#define loader_txt_end     binary___dsk2cdt_src_loader_txt_end
-#define loader_txt_size    binary___dsk2cdt_src_loader_txt_size
+#define loader_txt_start   binary___loader_donotedit_crlf_bin_start
+#define loader_txt_end     binary___loader_donotedit_crlf_bin_end
+#define loader_txt_size    binary___loader_donotedit_crlf_bin_size
 
 #define rsx_bin_start      binary_rsx_bin_start
 #define rsx_bin_end        binary_rsx_bin_end
@@ -26,9 +26,9 @@ extern size_t binary_rsx_bin_size[];
 
 // symbols exported by loader.o
 
-extern char _binary___dsk2cdt_src_loader_txt_start[];
-extern char _binary___dsk2cdt_src_loader_txt_end[];
-extern char _binary___dsk2cdt_src_loader_txt_size[];
+extern char _binary_loader_donotedit_crlf_bin_start[];
+extern char _binary_loader_donotedit_crlf_bin_end[];
+extern char _binary_loader_donotedit_crlf_bin_size[];
 extern char _binary___dsk2cdt_src_rsx_bin_start[];
 extern size_t _binary___dsk2cdt_src_rsx_bin_end[];
 extern size_t _binary___dsk2cdt_src_rsx_bin_size[];
@@ -36,9 +36,9 @@ extern size_t _binary___dsk2cdt_src_rsx_bin_size[];
 // the symbols out of ld are unwieldy, so make them easier to work with.
 // gcc doesn't let us do symbol aliasing with external symbols, bah
 
-#define loader_txt_start   _binary___dsk2cdt_src_loader_txt_start
-#define loader_txt_end     _binary___dsk2cdt_src_loader_txt_end
-#define loader_txt_size    _binary___dsk2cdt_src_loader_txt_size
+#define loader_txt_start   _binary_loader_donotedit_crlf_bin_start
+#define loader_txt_end     _binary_loader_donotedit_crlf_bin_end
+#define loader_txt_size    _binary_loader_donotedit_crlf_bin_size
 
 #define rsx_bin_start      _binary___dsk2cdt_src_rsx_bin_start
 #define rsx_bin_end        _binary___dsk2cdt_src_rsx_bin_end

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -4,4 +4,6 @@ Download exomizer and 2cdt and extract somewhere
 Edit Makefile and change EXOMIZER_PATH and 2CDT_PATH
 to point to the appropriate directories
 
+Make sure you have `unix2dos` utility in you path.
+
 make


### PR DESCRIPTION
… the file was checked out.

Fixes #4 here.

```
make: Entering directory '.../dsk2cdt2disc/src'
unix2dos -n ./dsk2cdt-src/loader.txt loader_donotedit.crlf.bin.tmp && mv -vf loader_donotedit.crlf.bin.tmp loader_donotedit.crlf.bin
unix2dos: converting file ./dsk2cdt-src/loader.txt to file loader_donotedit.crlf.bin.tmp in DOS format ...
'loader_donotedit.crlf.bin.tmp' -> 'loader_donotedit.crlf.bin'
ld -r -b binary -o loader.o loader_donotedit.crlf.bin rsx.bin
make: Leaving directory '.../dsk2cdt2disc/src'
```
