### PR TITLE
Compute output file name from input file name.

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -16,7 +16,7 @@ jobs:
     - run: sudo apt -y install binutils-z80 dos2unix gcc-mingw-w64
     - run: make thirdparty
     - run: CC=x86_64-w64-mingw32-gcc make
-    - run: mv dsk2cdt dsk2cdt.exe && mv readme.md readme.txt
+    - run: if [ -e dsk2cdt ] ; then mv dsk2cdt dsk2cdt.exe ; fi && mv readme.md readme.txt
     - uses: actions/upload-artifact@v2
       with:
         name: dsk2cdt

--- a/src/dsk2cdt.c
+++ b/src/dsk2cdt.c
@@ -243,8 +243,10 @@ int main(int argc, char *argv[])
     write_dib(pCDTFile, pRSXBlock, dib);
 
     {
-      char cdtname[21];
-      snprintf(cdtname, 20, "side%d.cdt", side_num+1);
+      int file_name_buffer_length = strlen(argv[1])+10+1; // with the zero end-of-string marker
+      char cdtname[file_name_buffer_length];
+      snprintf(cdtname, file_name_buffer_length, "%s_side%d.cdt", argv[1], side_num+1);
+      printf("output file name %s\n", cdtname);
       TZX_WriteFile(pCDTFile, cdtname);
       TZX_FreeFile(pCDTFile);
     }


### PR DESCRIPTION
When one wish to prepare several images in the same directory,
(also on unattended workflows)
this eliminates a cumbersome rename operation.
And even if one operation is done, the file name makes it clear
from which image the cdt was generated.
